### PR TITLE
Fixed the statusBar color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.1.7+1] - (1th September 2019)
+
+* Check for `minSdkVersion` >= 21 to add code for changing status bar color to transparent ([#12](https://github.com/henriquearthur/flutter_native_splash/issues/12))
+
 ## [0.1.7] - (27th August 2019)
 
 * Fix a bug that duplicates entries on `Info.plist` when using multiple `</dict>` on iOS ([#5](https://github.com/henriquearthur/flutter_native_splash/issues/5))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.1.7+2] - (1th September 2019)
+
+* Fix a bug on `minSdkVersion` reading ([#13](https://github.com/henriquearthur/flutter_native_splash/issues/13))
+
 ## [0.1.7+1] - (1th September 2019)
 
 * Check for `minSdkVersion` >= 21 to add code for changing status bar color to transparent ([#12](https://github.com/henriquearthur/flutter_native_splash/issues/12))

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ First, add `flutter_native_splash` as a [dev dependency in your pubspec.yaml fil
 
 ```yaml
 dev_dependencies:
-  flutter_native_splash: ^0.1.7+1
+  flutter_native_splash: ^0.1.7+2
 ```
 
 Don't forget to `flutter pub get`.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ First, add `flutter_native_splash` as a [dev dependency in your pubspec.yaml fil
 
 ```yaml
 dev_dependencies:
-  flutter_native_splash: ^0.1.7
+  flutter_native_splash: ^0.1.7+1
 ```
 
 Don't forget to `flutter pub get`.
@@ -48,6 +48,9 @@ flutter pub pub run flutter_native_splash:create
 ```
 
 When the package finishes running your splash screen is ready.
+
+## Notes
+* If `minSdkVersion` < 21 the code for changing status bar color to transparent will not be added. If later on you change your `minSdkVersion` to >= 21 you need to manually add code for changing status bar color if you want to.
 
 ## Recommendations
 * If you want to use a Material Icon as your splash image, download an icon in [(material.io/resources/icons)](https://material.io/resources/icons/) as **PNG** for **Android**. I recommend using the biggest icon in `drawable-xxxhdpi` folder which was just downloaded for better results.

--- a/lib/android.dart
+++ b/lib/android.dart
@@ -465,8 +465,11 @@ Future<bool> _supportStatusBarCode() async {
     String line = lines[x];
 
     if (line.contains('minSdkVersion')) {
-      int minSdkVersion =
-          int.parse(line.replaceAll('minSdkVersion', '').trim());
+      RegExp regExp = RegExp(r'minSdkVersion([ \t]*)([0-9]*)');
+      var matches = regExp.allMatches(line);
+      var match = matches.elementAt(0);
+
+      int minSdkVersion = int.parse(match.group(2));
 
       // android.view.Window.setStatusBarColor was introduced in API 21
       if (minSdkVersion >= 21) {

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -5,6 +5,7 @@ const String androidLaunchBackgroundFile =
     'android/app/src/main/res/drawable/launch_background.xml';
 const String androidStylesFile = 'android/app/src/main/res/values/styles.xml';
 const String androidResFolder = 'android/app/src/main/res/';
+const String androidBuildGradleAppFile = 'android/app/build.gradle';
 
 // iOS-related constants
 const String iOSAssetsLaunchImageFolder =

--- a/lib/templates.dart
+++ b/lib/templates.dart
@@ -40,9 +40,13 @@ import android.view.ViewTreeObserver;
 import android.view.WindowManager;
 ''';
 
-const String androidMainActivityJavaLines2 = '''
+const String androidMainActivityJavaLines2WithStatusBar = '''
     boolean flutter_native_splash = true;
     getWindow().setStatusBarColor(0x00000000);
+''';
+
+const String androidMainActivityJavaLines2WithoutStatusBar = '''
+    boolean flutter_native_splash = true;
 ''';
 
 const String androidMainActivityJavaLines3 = '''
@@ -61,9 +65,13 @@ import android.view.ViewTreeObserver
 import android.view.WindowManager
 ''';
 
-const String androidMainActivityKotlinLines2 = '''
+const String androidMainActivityKotlinLines2WithStatusBar = '''
     val flutter_native_splash = true
     window.statusBarColor = 0x00000000
+''';
+
+const String androidMainActivityKotlinLines2WithoutStatusBar = '''
+    val flutter_native_splash = true
 ''';
 
 const String androidMainActivityKotlinLines3 = '''

--- a/lib/templates.dart
+++ b/lib/templates.dart
@@ -41,12 +41,12 @@ import android.view.WindowManager;
 ''';
 
 const String androidMainActivityJavaLines2WithStatusBar = '''
-    boolean flutter_native_splash = true;
-    getWindow().setStatusBarColor(0x00000000);
+    boolean flutterNativeSplash = true;
+    getWindow().setStatusBarColor(primaryColorDark);
 ''';
 
 const String androidMainActivityJavaLines2WithoutStatusBar = '''
-    boolean flutter_native_splash = true;
+    boolean flutterNativeSplash = true;
 ''';
 
 const String androidMainActivityJavaLines3 = '''
@@ -66,12 +66,12 @@ import android.view.WindowManager
 ''';
 
 const String androidMainActivityKotlinLines2WithStatusBar = '''
-    val flutter_native_splash = true
-    window.statusBarColor = 0x00000000
+    val flutterNativeSplash = true
+    window.statusBarColor = primaryColorDark
 ''';
 
 const String androidMainActivityKotlinLines2WithoutStatusBar = '''
-    val flutter_native_splash = true
+    val flutterNativeSplash = true
 ''';
 
 const String androidMainActivityKotlinLines3 = '''
@@ -131,11 +131,11 @@ String iOSInfoPlistLines = '''
 ''';
 
 String iOSAppDelegateObjectiveCLines = '''
-    int flutter_native_splash = 1;
+    int flutterNativeSplash = 1;
     UIApplication.sharedApplication.statusBarHidden = false;
 ''';
 
 String iOSAppDelegateSwiftLines = '''
-    var flutter_native_splash = 1
+    var flutterNativeSplash = 1
     UIApplication.shared.isStatusBarHidden = false
 ''';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_native_splash
 description: Automatically generates native code for adding splash screens in Android and iOS. Customize with specific platform, background color and splash image.
-version: 0.1.7+1
+version: 0.1.7+2
 homepage: https://github.com/henriquearthur/flutter_native_splash
 author: Henrique Arthur <eu@henriquearthur.com.br>
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_native_splash
 description: Automatically generates native code for adding splash screens in Android and iOS. Customize with specific platform, background color and splash image.
-version: 0.1.7+2
+version: 0.1.7+3
 homepage: https://github.com/henriquearthur/flutter_native_splash
 author: Henrique Arthur <eu@henriquearthur.com.br>
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_native_splash
 description: Automatically generates native code for adding splash screens in Android and iOS. Customize with specific platform, background color and splash image.
-version: 0.1.7
+version: 0.1.7+1
 homepage: https://github.com/henriquearthur/flutter_native_splash
 author: Henrique Arthur <eu@henriquearthur.com.br>
 


### PR DESCRIPTION
Before the plugins set the status bar color to white. As a consequence, it overrides the status bar color defined by the material swatches.

I looked in the Flutter source code to look for how they generate the material color swatch used the same principles to generate the material color dark for every color