### PR TITLE
Prevent unhandler int exception in color argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.1.8+3] - (4th October 2019)
+
+* Prevent unhandler int exception in `color` argument (thanks [@wemersonrv](https://github.com/wemersonrv) - PR [#23](https://github.com/henriquearthur/flutter_native_splash/pull/23))
+
 ## [0.1.8+2] - (16th September 2019)
 
 * Fix code being added multiple times to `MainActivity` ([#19](https://github.com/henriquearthur/flutter_native_splash/issues/19))

--- a/lib/flutter_native_splash.dart
+++ b/lib/flutter_native_splash.dart
@@ -12,7 +12,7 @@ void createSplash() async {
   Map<String, dynamic> config = await _getConfig();
 
   String image = config['image'];
-  String color = config['color'];
+  String color = config['color'].toString();
   bool fill = config['fill'] ?? false;
   bool androidDisableFullscreen = config['android_disable_fullscreen'] ?? false;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_native_splash
 description: Automatically generates native code for adding splash screens in Android and iOS. Customize with specific platform, background color and splash image.
-version: 0.1.8+2
+version: 0.1.8+3
 homepage: https://github.com/henriquearthur/flutter_native_splash
 author: Henrique Arthur <eu@henriquearthur.com.br>
 


### PR DESCRIPTION
Add `toString()` to `color` settings key, avoiding type exception when uses a hex collor only with numbers like `211915 (#211915)`.

In example below, `collor` assumes an int type and will crash with type exception:
```yaml
flutter_native_splash:
  image: assets/png/startup_splash.png
  color: 211915
  fill: true
```